### PR TITLE
Add Pylint to workflow actions

### DIFF
--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -6,6 +6,21 @@ on:
    - main
 
 jobs:
+ pylint_run:
+  name: "Run Pylint"
+  runs-on: ubuntu-latest
+  steps:
+   - name: clone repository
+     uses: actions/checkout@v3
+   - name: Install Python
+     uses: actions/setup-python@v4.6.0
+   - name: Install pylint
+     run: pip3 install pylint
+   - name: Install packages
+     run: pip3 install -r ./requirements.txt
+   - name: Python Linter on functions
+     run: pylint --fail-under=8 ./functions/*.py
+
  pytest_run:
   name: "Run Pytest"
   runs-on: ubuntu-latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-dotenv
 requests
+pylint


### PR DESCRIPTION
Add pylint to workflow actions (specifically for all .py files within /functions).

Workflow will fail for a pylint score below 8.